### PR TITLE
Python 2 compatibility

### DIFF
--- a/pyaffy/celparser.pyx
+++ b/pyaffy/celparser.pyx
@@ -53,8 +53,11 @@ import dateutil
 import codecs
 from collections import OrderedDict
 
-
-from configparser import ConfigParser, ParsingError
+try:
+    from configparser import ConfigParser, ParsingError
+except ImportError:
+    # python 2
+    from ConfigParser import ConfigParser, ParsingError
 
 logger = logging.getLogger(__name__)
 logger.debug('__name__: %s', __name__)


### PR DESCRIPTION
Running the example at https://github.com/flo-compbio/pyaffy-demos/blob/master/minimal/01%20-%20Downloading%20the%20data%20and%20running%20pyAffy.ipynb failed with the error:

```
---------------------------------------------------------------------------
ImportError                               Traceback (most recent call last)
<ipython-input-10-88020abe5a90> in <module>()
      1 from collections import OrderedDict
      2 from genometools import misc
----> 3 from pyaffy import rma
      4 
      5 misc.get_logger(verbose = False)

/home/maxim/anaconda2/lib/python2.7/site-packages/pyaffy/__init__.py in <module>()
     17 import pkg_resources
     18 
---> 19 from .process import rma
     20 
     21 __version__ = pkg_resources.require('pyaffy')[0].version

/home/maxim/anaconda2/lib/python2.7/site-packages/pyaffy/process.py in <module>()
     26 
     27 from .cdfparser import parse_cdf
---> 28 from . import celparser
     29 from .celparser import parse_cel
     30 from .medpolish import medpolish

pyaffy/celparser.pyx in init pyaffy.celparser (pyaffy/celparser.c:30633)()

ImportError: No module named configparser
```

This should fix.
